### PR TITLE
Proposed solution for #8

### DIFF
--- a/tasks/nodeunit.js
+++ b/tasks/nodeunit.js
@@ -197,7 +197,7 @@ module.exports = function(grunt) {
             if(files.length > 0){
               grunt.warn('0/0 assertions ran (' + assertions.duration + 'ms)');
             } else {
-              grunt.log.ok('No test files found, so no assertions was run.');
+              grunt.log.ok('No test files found, so no assertions were run.');
             }
           } else {
             grunt.verbose.writeln();


### PR DESCRIPTION
Adding proposal to solve #8, updated `done` method:

``` javascript
// Executed when everything is all done.
done: function (assertions) {
  (...)
  } else if (assertions.length === 0) {
    if(files.length > 0){
      grunt.warn('0/0 assertions ran (' + assertions.duration + 'ms)');
    } else {
      grunt.log.ok('No test files found, so no assertions was run.');
    }
  } 
  (...)
}
```
