### PR TITLE
Upgrade to nodeunit 0.8.0 to support node 0.10.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "test": "grunt test"
   },
   "dependencies": {
-    "nodeunit": "~0.7.4"
+    "nodeunit": "~0.8.0"
   },
   "devDependencies": {
     "grunt-contrib-jshint": "~0.2.0",


### PR DESCRIPTION
Running many tests causes the following warnings.

```
(node) warning: Recursive process.nextTick detected. This will break in the next version of node. Please use setImmediate for recursive deferral.
```

This was fixed in nodeunit 0.8.0. Bumping the version number in the `package.json` seems to solve the issue.

See https://github.com/caolan/nodeunit/pull/195
