### PR TITLE
Allow missing operators on error objects.

### DIFF
--- a/tasks/nodeunit.js
+++ b/tasks/nodeunit.js
@@ -38,7 +38,7 @@ module.exports = function(grunt) {
     var expected = util.inspect(e.expected, false, 10, true);
 
     var indent = function(str) {
-      return str.split('\n').map(function(s) { return '  ' + s; }).join('\n');
+      return (''+str).split('\n').map(function(s) { return '  ' + s; }).join('\n');
     };
 
     var stack;

--- a/test/fixtures/fail.js
+++ b/test/fixtures/fail.js
@@ -5,4 +5,14 @@ exports.fail = {
     test.ok(undefined, 'this value should be truthy');
     test.done();
   },
+  failSupertestError: function(test) {
+    var error = new Error('Something arbitrary');
+    // Must be long enough that the inspect calls try to
+    // wrap the line for indentation.
+    error.actual = { foo: 'bar', something: 'complex', more: 'more' };
+    error.expected = "No you didn't"
+    error.showDiff = true;
+    throw(error);
+    test.done();
+  },
 };

--- a/test/nodeunit_test.js
+++ b/test/nodeunit_test.js
@@ -9,11 +9,12 @@ exports.nodeunit = {
     test.done();
   },
   fail: function(test) {
-    test.expect(2);
+    test.expect(3);
     grunt.util.spawn({
       grunt: true,
       args: ['test:fail', '--no-color'],
     }, function(err, result) {
+      test.ok(result.stdout.indexOf("Operator:") !== -1, 'Operator should display for multiline.');
       test.ok(result.stdout.indexOf('Message: this value should be truthy') !== -1, 'Message should have been displayed.');
       test.ok(result.stdout.indexOf('Error: undefined == true') !== -1, 'Error should have been displayed.');
       test.done();


### PR DESCRIPTION
[supertest](https://github.com/visionmedia/supertest/) kicks out an error object that lacks an operator property (see [code](https://github.com/visionmedia/supertest/blob/master/lib/test.js#L207-L213)). Most of the time this has no impact, but when there is also a multi-line object to display as actual or expected value the operator must be formatted. The indent function must therefore be undefined-safe.
