### PR TITLE
Require nodeunit >= 0.8.4 that has the proper reporter callbacks for the...

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "test": "grunt test"
   },
   "dependencies": {
-    "nodeunit": "~0.8.0"
+    "nodeunit": ">= 0.8.4"
   },
   "devDependencies": {
     "grunt-contrib-jshint": "~0.7.2",


### PR DESCRIPTION
nodeunit dependency updated to 0.8.4 which has the proper reporter callbacks for the `reporter` and `reporterOutput` options
