### PR TITLE
Adds options.reporterOptions to pass in options to the nodeunit reporter

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -82,6 +82,22 @@ module.exports = function(grunt) {
     grunt.task.run('nodeunit');
   });
 
+  // Tests nodeunit with junit reporter
+  grunt.registerTask('test-junit', function(which) {
+    var test = path.join('test', 'fixtures', which + '.js');
+    var outDir = path.join('tmp', which + '.junit');
+    
+    if (grunt.file.exists(test)) {
+      grunt.config('nodeunit.tests', test);
+    }
+
+    grunt.config('nodeunit.options.reporter', 'junit');
+    grunt.config('nodeunit.options.reporterOptions', { output: outDir });
+
+    grunt.task.run('clean');
+    grunt.task.run('nodeunit');
+  });
+
   // By default, lint and run all tests.
   grunt.registerTask('default', ['jshint', 'nodeunit', 'build-contrib']);
 };

--- a/README.md
+++ b/README.md
@@ -43,6 +43,27 @@ Specifies the reporter you want to use. For example, `default`, `verbose` or `ta
 
 Specifies the file the `reporter`'s output should be saved to. For example, `tests.tap`.
 
+#### options.reporterOptions
+* Type: `Object`
+* Default: `{}`
+
+Specifies the options passed to the `reporter`.  For example, the `junit` reporter requires the `output` option
+to be set:
+
+```js
+grunt.initConfig({
+  nodeunit: {
+    all: ['test/*_test.js'],
+    options: {
+      reporter: 'junit',
+      reporterOptions: {
+        output: 'outputdir'
+      }
+    }
+  }
+});
+```
+
 ### Usage examples
 
 #### Wildcards
@@ -77,7 +98,10 @@ grunt.initConfig({
     all: ['test/*_test.js'],
     options: {
       reporter: 'tap',
-      reporterOutput: 'tests.tap'
+      reporterOutput: 'tests.tap',
+      reporterOptions: {
+        output: 'outputdir'
+      }
     }
   }
 });
@@ -100,4 +124,4 @@ grunt.initConfig({
 
 Task submitted by ["Cowboy" Ben Alman](http://benalman.com)
 
-*This file was generated on Sun Jan 26 2014 20:00:41.*
+*This file was generated on Thu Feb 13 2014 13:57:08.*

--- a/docs/nodeunit-examples.md
+++ b/docs/nodeunit-examples.md
@@ -32,7 +32,10 @@ grunt.initConfig({
     all: ['test/*_test.js'],
     options: {
       reporter: 'tap',
-      reporterOutput: 'tests.tap'
+      reporterOutput: 'tests.tap',
+      reporterOptions: {
+        output: 'outputdir'
+      }
     }
   }
 });

--- a/docs/nodeunit-options.md
+++ b/docs/nodeunit-options.md
@@ -11,3 +11,24 @@ Specifies the reporter you want to use. For example, `default`, `verbose` or `ta
 * Default: `false`  
 
 Specifies the file the `reporter`'s output should be saved to. For example, `tests.tap`.
+
+## options.reporterOptions
+* Type: `Object`
+* Default: `{}`
+
+Specifies the options passed to the `reporter`.  For example, the `junit` reporter requires the `output` option
+to be set:
+
+```js
+grunt.initConfig({
+  nodeunit: {
+    all: ['test/*_test.js'],
+    options: {
+      reporter: 'junit',
+      reporterOptions: {
+        output: 'outputdir'
+      }
+    }
+  }
+});
+```

--- a/tasks/nodeunit.js
+++ b/tasks/nodeunit.js
@@ -223,6 +223,7 @@ module.exports = function(grunt) {
     var options = this.options({
       reporterOutput: false,
       reporter: 'grunt',
+      reporterOptions: {}
     });
 
     if (!nodeunit.reporters[options.reporter]) {
@@ -243,7 +244,7 @@ module.exports = function(grunt) {
     }
 
     // Run test(s).
-    nodeunit.reporters[options.reporter].run(this.filesSrc, {}, function(err) {
+    nodeunit.reporters[options.reporter].run(this.filesSrc, options.reporterOptions, function(err) {
       // Write the output of the reporter if wanted
       if (options.reporterOutput) {
         // no longer hook stdout so we can grunt.log

--- a/test/nodeunit_test.js
+++ b/test/nodeunit_test.js
@@ -26,7 +26,7 @@ exports.nodeunit = {
     grunt.util.spawn({
       grunt: true,
       args: ['test-tap:fail', '--no-color'],
-    }, function(err, result,code) {
+    }, function(err, result, code) {
       // stdout message
       test.ok(result.stdout.indexOf('# fail - fail') !== -1, 'First test should fail');
       test.ok(result.stdout.indexOf('not ok 1 this value should be truthy') !== -1, 'First test failure notice');
@@ -43,8 +43,8 @@ exports.nodeunit = {
     grunt.util.spawn({
       grunt: true,
       args: ['test-tap-out:fail', '--no-color'],
-    }, function(err, result,code) {
-      // stdout message
+    }, function(err, result, code) {
+      // stdout message  
       test.ok(result.stdout.indexOf('fail.js.tap" created') !== -1, 'File creation notice should be displayed.');
 
       // verify parts of the fail.js.tap contents against ours
@@ -57,6 +57,25 @@ exports.nodeunit = {
       test.ok(tapContents.indexOf('not ok 2 Something arbitrary') !== -1, 'Second test failure message');
       test.ok(tapContents.indexOf('# tests 2') !== -1, 'Total test count');
       test.ok(tapContents.indexOf('# fail  2') !== -1, 'Total failure count');
+
+      test.done();
+    });
+  },
+  junit: function(test) {
+    test.expect(4);
+    grunt.util.spawn({
+      grunt: true,
+      args: ['test-junit:fail', '--no-color'],
+    }, function(err, result,code) {
+      // verify the junit directory exists
+      var junitDir = path.join('tmp', 'fail.junit');
+      var junitFile = path.join(junitDir, 'fail.js.xml');
+      var junitContents = grunt.util.normalizelf(grunt.file.read(junitFile));
+
+      test.ok(junitContents.indexOf('<testsuite name="fail.js"') !== -1, 'testsuite element');
+      test.ok(junitContents.indexOf('errors="2"') !== -1, 'Two errors detected');
+      test.ok(junitContents.indexOf('AssertionError: this value should be truthy') !== -1, 'Assertion');
+      test.ok(junitContents.indexOf('fail - failSupertestError') !== -1, 'Failure message');
 
       test.done();
     });


### PR DESCRIPTION
This is required for some reporters such as `junit`, which requires an `output` option.

See https://github.com/gruntjs/grunt-contrib-nodeunit/issues/20

Also includes tests.
