### PR TITLE
Update nodeunit to v0.9.0 / Remove grunt.util.hooker

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "test": "grunt test"
   },
   "dependencies": {
+    "hooker": "~0.2.3",
     "nodeunit": "~0.9.0"
   },
   "devDependencies": {

--- a/tasks/nodeunit.js
+++ b/tasks/nodeunit.js
@@ -17,6 +17,7 @@ module.exports = function(grunt) {
 
   // External libs.
   var nodeunit = require('nodeunit');
+  var hooker = require('hooker');
 
   // ==========================================================================
   // BETTER ERROR DISPLAY
@@ -254,7 +255,6 @@ module.exports = function(grunt) {
     }
 
     var output = '';
-    var hooker = grunt.util.hooker;
 
     if (options.reporterOutput) {
       // Hook into stdout to capture report


### PR DESCRIPTION
[`grunt.util.hooker`](http://gruntjs.com/api/grunt.util#grunt.util.hooker) is [deprecated](https://github.com/gruntjs/grunt-legacy-util#grunt-legacy-util).
