### PR TITLE
Fixed unit test to run on Node v4.x and v5.x.

### DIFF
--- a/tasks/nodeunit.js
+++ b/tasks/nodeunit.js
@@ -40,8 +40,8 @@ module.exports = function(grunt) {
     e._message = e.message;
 
     // Pretty-formatted objects.
-    var actual = util.inspect(e.actual, false, 10, true);
-    var expected = util.inspect(e.expected, false, 10, true);
+    var actual = util.inspect(e.actual, { depth: 10, colors: true });
+    var expected = util.inspect(e.expected, { depth: 10, colors: true });
 
     var indent = function(str) {
       return ('' + str).split('\n').map(function(s) { return '  ' + s; }).join('\n');

--- a/test/fixtures/fail.js
+++ b/test/fixtures/fail.js
@@ -9,8 +9,8 @@ exports.fail = {
     var error = new Error('Something arbitrary');
     // Must be long enough that the inspect calls try to
     // wrap the line for indentation.
-    error.actual = { foo: 'bar', something: 'complex', more: 'more' };
-    error.expected = "No you didn't"
+    error.actual = { foo: 'bar', something: 'complex', more: 'more', even: 11335577992 };
+    error.expected = "No you didn't";
     error.showDiff = true;
     throw(error);
     test.done();


### PR DESCRIPTION
Fixes #41.

Expanded unit test properties to force carriage return. See util.js [new reduceToSingleString](https://github.com/nodejs/node/blob/836c659d8f0b7683b7c1269b6d5ce567d7fa3a90/lib/util.js#L663) method vs [old reduceToSingleString](https://github.com/nodejs/node/blob/0e0aa28871732c57a2e11bd6e4371f8f98331e41/lib/util.js#L414).

Bonus: Added missing semicolon and updated util.inspect API call to current.